### PR TITLE
fix: changed the peripheral characters to prevent misunderstood

### DIFF
--- a/commit-msg-linter.js
+++ b/commit-msg-linter.js
@@ -491,7 +491,7 @@ function decorate(text, invalid, required = true) {
  * addPeripherals('type')
  * // => "<type>"
  * addPeripherals('scope', false)
- * // => "[scope]"
+ * // => "(scope)"
  *
  * @param {string} text
  * @param {boolean} required
@@ -503,7 +503,7 @@ function addPeripherals(text, required = true) {
     return `<${text}>`;
   }
 
-  return `[${text}]`;
+  return `(${text})`;
 }
 
 /**


### PR DESCRIPTION
The correct format for a commit is

`<type>(<scope>): <subject>`

but, when is inserted a invalid message, is showed the format:
`<type>[scope]: <subject>`

The use of `[ ]` in example, maybe is a misunderstood to the correct format.

This PR will change the characters `[ ]` to `( )` to show the correct format for the user