### PR TITLE
ci: add changeset to release pkg automatically

### DIFF
--- a/.changeset/big-numbers-mix.md
+++ b/.changeset/big-numbers-mix.md
@@ -1,0 +1,5 @@
+---
+"git-commit-msg-linter": patch
+---
+
+ci: add changeset to release pkg automatically

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "baseBranch": "master",
+  "access": "public"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: Install Dependencies
+        run: npm i pnpm -g && pnpm i
+
+      - name: Create Release Pull Request or Publish to npm
+        # https://github.com/changesets/action
+        uses: changesets/action@v1
+        with:
+          publish: pnpm changeset publish
+          commit: 'chore: release'
+          title: 'chore: release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "node": ">= 8.0.0"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.26.0",
     "eslint": "^7.28.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.23.4",


### PR DESCRIPTION
Steps for you:
1. Open `Settings` -> `Actions` -> `General`, and then tick `Allow GitHub Actions to create and approve pull requests`
2. Open `Settings` -> `Secrets and variables` -> `Actions`，and then create a `NPM_TOKEN`.
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/35495628/224712228-33354d11-f38e-411c-a3f8-f2105d8df13c.png">
3. Accept this PR.

After finishing steps above, github bot will create a PR named `chore: release` automatically. If you accept the `chore: release` PR, github action will release this pkg to npm.

Check the example of my project: https://github.com/zanminkian/tsconfig. 
Check the doc of changesets action: https://github.com/changesets/action